### PR TITLE
Remove 'wireless' exclusivity

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Local Peer-to-Peer API enables mobile and desktop devices to transfer messages or files through close-range wireless communication in a privacy-preserving manner.
+The Local Peer-to-Peer API enables mobile and desktop devices to transfer messages or files through close-range communication in a privacy-preserving manner.
 
 This proposed high-level Web API aspires to provide a web-friendly abstraction that hides the complexity of various underlying peer-to-peer technologies from both users and web developers. 
 
@@ -33,7 +33,7 @@ When a user wants to transfer a file from a web site to another device nearby—
 
 3. Email. A file can be sent as an email attachment using a cloud-based service. Arbitrary email attachment size limitations cause frustration and the common Base64 encoding for attachments adds about 37% to the original file size. Arguably an email-as-a-file-sharing-service has a suboptimal user experience.
 
-None of these solutions to this seemingly common task provide a compelling user experience. When the devices are physically nearby the user's expectation is the file transfer would be as quick and seamless as handing out physical objects to another person close by. With close-range wireless communication technologies widely supported on today's devices we believe this user experience can be vastly improved.
+None of these solutions to this seemingly common task provide a compelling user experience. When the devices are physically nearby the user's expectation is the file transfer would be as quick and seamless as handing out physical objects to another person close by. With close-range communication technologies widely supported on today's devices we believe this user experience can be vastly improved.
 
 We need an optimized network path to use a local network connected by the devices for web applications.
 
@@ -113,7 +113,7 @@ This section represents concepts of how a user could discover, connect and share
 
 ## Goals
 
-Build a generic local peer-to-peer API and provide an arbitrary bidirectional channel on the web for devices under short-range wireless communication environment.
+Build a generic local peer-to-peer API and provide an arbitrary bidirectional channel on the web for devices under short-range communication environment.
 
 The API will abstract over peer-to-peer technology and provide a high-level interface for two instances of a web app running on peer devices to discover and connect to each other.
 


### PR DESCRIPTION
Also wired implementations are in scope.
For example both Wi-Fi and Ethernet are
supported by Open Screen Library.